### PR TITLE
Add migration scripts with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # o365-toolbox
-Toolbox 0365 - Migration tenant O365
+
+A set of PowerShell scripts to migrate mail related objects from the domain
+`webetsolutions.com` to `oasis-projet.com` and to roll back if needed. Each
+script writes a log and CSV report in the current directory.
+
+Run `menu_migration.ps1` from the `scripts` folder to access a menu that
+triggers the different migration or rollback actions.

--- a/scripts/bal_migrate.ps1
+++ b/scripts/bal_migrate.ps1
@@ -1,0 +1,45 @@
+# Migrates user mailboxes from webetsolutions.com to oasis-projet.com
+$oldDomain = "webetsolutions.com"
+$newDomain = "oasis-projet.com"
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_BAL_user_to_oasis_$timestamp.log"
+$csvFile   = "./migration_BAL_user_to_oasis_$timestamp.csv"
+$results   = @()
+
+$userMailboxes = Get-Mailbox -ResultSize Unlimited -RecipientTypeDetails UserMailbox
+foreach ($mb in $userMailboxes) {
+    $prefix = $mb.PrimarySmtpAddress.Local
+    $currentPrimary = $mb.PrimarySmtpAddress.ToString()
+    if ($currentPrimary -like "*@$oldDomain") {
+        $newPrimary = "SMTP:$prefix@$newDomain"
+        $oldAlias   = "smtp:$prefix@$oldDomain"
+        try {
+            Write-Host "➡ Migration: $($mb.DisplayName) -> $newPrimary" -ForegroundColor Cyan
+            Set-Mailbox -Identity $mb.Identity -EmailAddresses @($newPrimary, $oldAlias)
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Migrated"
+            }
+        } catch {
+            Write-Warning "⛔ Erreur sur $($mb.DisplayName): $_"
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Error: $($_.Exception.Message)"
+            }
+        }
+    } else {
+        Write-Host "⏭ Déjà migrée ou autre domaine: $($mb.DisplayName)" -ForegroundColor DarkGray
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/bal_migrate_inverse.ps1
+++ b/scripts/bal_migrate_inverse.ps1
@@ -1,0 +1,45 @@
+# Rollback user mailboxes from oasis-projet.com back to webetsolutions.com
+$oldDomain = "oasis-projet.com"
+$newDomain = "webetsolutions.com"
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./reverse_migration_BAL_user_to_web_$timestamp.log"
+$csvFile   = "./reverse_migration_BAL_user_to_web_$timestamp.csv"
+$results   = @()
+
+$userMailboxes = Get-Mailbox -ResultSize Unlimited -RecipientTypeDetails UserMailbox
+foreach ($mb in $userMailboxes) {
+    $prefix = $mb.PrimarySmtpAddress.Local
+    $currentPrimary = $mb.PrimarySmtpAddress.ToString()
+    if ($currentPrimary -like "*@$oldDomain") {
+        $newPrimary = "SMTP:$prefix@$newDomain"
+        $oldAlias   = "smtp:$prefix@$oldDomain"
+        try {
+            Write-Host "↩ Rétro-migration: $($mb.DisplayName) -> $newPrimary" -ForegroundColor Yellow
+            Set-Mailbox -Identity $mb.Identity -EmailAddresses @($newPrimary, $oldAlias)
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Reverted"
+            }
+        } catch {
+            Write-Warning "⛔ Erreur sur $($mb.DisplayName): $_"
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Error: $($_.Exception.Message)"
+            }
+        }
+    } else {
+        Write-Host "⏭ Déjà sur $newDomain ou autre domaine: $($mb.DisplayName)" -ForegroundColor DarkGray
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/balp_migrate.ps1
+++ b/scripts/balp_migrate.ps1
@@ -1,0 +1,45 @@
+# Migrates shared mailboxes from webetsolutions.com to oasis-projet.com
+$oldDomain = "webetsolutions.com"
+$newDomain = "oasis-projet.com"
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_BALP_to_oasis_$timestamp.log"
+$csvFile   = "./migration_BALP_to_oasis_$timestamp.csv"
+$results   = @()
+
+$sharedMailboxes = Get-Mailbox -ResultSize Unlimited -RecipientTypeDetails SharedMailbox
+foreach ($mb in $sharedMailboxes) {
+    $prefix = $mb.PrimarySmtpAddress.Local
+    $currentPrimary = $mb.PrimarySmtpAddress.ToString()
+    if ($currentPrimary -like "*@$oldDomain") {
+        $newPrimary = "SMTP:$prefix@$newDomain"
+        $oldAlias   = "smtp:$prefix@$oldDomain"
+        try {
+            Write-Host "➡ Migration: $($mb.DisplayName) -> $newPrimary" -ForegroundColor Cyan
+            Set-Mailbox -Identity $mb.Identity -EmailAddresses @($newPrimary, $oldAlias)
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Migrated"
+            }
+        } catch {
+            Write-Warning "⛔ Erreur sur $($mb.DisplayName): $_"
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Error: $($_.Exception.Message)"
+            }
+        }
+    } else {
+        Write-Host "⏭ Déjà migrée ou autre domaine: $($mb.DisplayName)" -ForegroundColor DarkGray
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/balp_migrate_inverse.ps1
+++ b/scripts/balp_migrate_inverse.ps1
@@ -1,0 +1,45 @@
+# Rollback shared mailboxes from oasis-projet.com back to webetsolutions.com
+$oldDomain = "oasis-projet.com"
+$newDomain = "webetsolutions.com"
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_BALP_reverse_$timestamp.log"
+$csvFile   = "./migration_BALP_reverse_$timestamp.csv"
+$results   = @()
+
+$sharedMailboxes = Get-Mailbox -ResultSize Unlimited -RecipientTypeDetails SharedMailbox
+foreach ($mb in $sharedMailboxes) {
+    $prefix = $mb.PrimarySmtpAddress.Local
+    $currentPrimary = $mb.PrimarySmtpAddress.ToString()
+    if ($currentPrimary -like "*@$oldDomain") {
+        $newPrimary = "SMTP:$prefix@$newDomain"
+        $oldAlias   = "smtp:$prefix@$oldDomain"
+        try {
+            Write-Host "↩ Rétro-migration: $($mb.DisplayName) -> $newPrimary" -ForegroundColor Yellow
+            Set-Mailbox -Identity $mb.Identity -EmailAddresses @($newPrimary, $oldAlias)
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Reverted"
+            }
+        } catch {
+            Write-Warning "⛔ Erreur sur $($mb.DisplayName): $_"
+            $results += [pscustomobject]@{
+                DisplayName = $mb.DisplayName
+                Identity    = $mb.Identity
+                OldPrimary  = $currentPrimary
+                NewPrimary  = "$prefix@$newDomain"
+                Timestamp   = (Get-Date)
+                Status      = "Error: $($_.Exception.Message)"
+            }
+        }
+    } else {
+        Write-Host "⏭ Déjà sur $newDomain ou autre domaine: $($mb.DisplayName)" -ForegroundColor DarkGray
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/contacts_externes_migrate.ps1
+++ b/scripts/contacts_externes_migrate.ps1
@@ -1,0 +1,38 @@
+# Migrates external contacts from webetsolutions.com to oasis-projet.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_contacts_to_oasis_$timestamp.log"
+$csvFile   = "./migration_contacts_to_oasis_$timestamp.csv"
+$results   = @()
+
+$contacts = Get-MailContact
+foreach ($contact in $contacts) {
+    if ($contact.ExternalEmailAddress -like "*@webetsolutions.com") {
+        $newEmail = $contact.ExternalEmailAddress.ToString().Replace("@webetsolutions.com", "@oasis-projet.com")
+        try {
+            Set-MailContact -Identity $contact.Identity -ExternalEmailAddress $newEmail
+            Write-Host "➡ Contact mis à jour : $($contact.DisplayName)" -ForegroundColor Cyan
+            $results += [pscustomobject]@{
+                DisplayName = $contact.DisplayName
+                Identity    = $contact.Identity
+                OldAddress  = $contact.ExternalEmailAddress.ToString()
+                NewAddress  = $newEmail
+                Timestamp   = (Get-Date)
+                Status      = "Migrated"
+            }
+        } catch {
+            Write-Warning "⛔ Erreur sur $($contact.DisplayName): $_"
+            $results += [pscustomobject]@{
+                DisplayName = $contact.DisplayName
+                Identity    = $contact.Identity
+                OldAddress  = $contact.ExternalEmailAddress.ToString()
+                NewAddress  = $newEmail
+                Timestamp   = (Get-Date)
+                Status      = "Error: $($_.Exception.Message)"
+            }
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/contacts_externes_migrate_inverse.ps1
+++ b/scripts/contacts_externes_migrate_inverse.ps1
@@ -1,0 +1,38 @@
+# Rollback external contacts from oasis-projet.com back to webetsolutions.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_contacts_reverse_$timestamp.log"
+$csvFile   = "./migration_contacts_reverse_$timestamp.csv"
+$results   = @()
+
+$contacts = Get-MailContact
+foreach ($contact in $contacts) {
+    if ($contact.ExternalEmailAddress -like "*@oasis-projet.com") {
+        $newEmail = $contact.ExternalEmailAddress.ToString().Replace("@oasis-projet.com", "@webetsolutions.com")
+        try {
+            Set-MailContact -Identity $contact.Identity -ExternalEmailAddress $newEmail
+            Write-Host "↩ Contact remis à jour : $($contact.DisplayName)" -ForegroundColor Yellow
+            $results += [pscustomobject]@{
+                DisplayName = $contact.DisplayName
+                Identity    = $contact.Identity
+                OldAddress  = $contact.ExternalEmailAddress.ToString()
+                NewAddress  = $newEmail
+                Timestamp   = (Get-Date)
+                Status      = "Reverted"
+            }
+        } catch {
+            Write-Warning "⛔ Erreur sur $($contact.DisplayName): $_"
+            $results += [pscustomobject]@{
+                DisplayName = $contact.DisplayName
+                Identity    = $contact.Identity
+                OldAddress  = $contact.ExternalEmailAddress.ToString()
+                NewAddress  = $newEmail
+                Timestamp   = (Get-Date)
+                Status      = "Error: $($_.Exception.Message)"
+            }
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/group_m365_migrate_inverse.ps1
+++ b/scripts/group_m365_migrate_inverse.ps1
@@ -1,0 +1,36 @@
+# Rollback M365 groups from oasis-projet.com back to webetsolutions.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_groups_reverse_$timestamp.log"
+$csvFile   = "./migration_groups_reverse_$timestamp.csv"
+$results   = @()
+
+$groups = Get-UnifiedGroup
+foreach ($group in $groups) {
+    $prefix = $group.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@webetsolutions.com"
+    $oldAlias   = "smtp:$prefix@oasis-projet.com"
+    try {
+        Write-Host "↩ Rétro-migration: $($group.DisplayName) -> $newPrimary" -ForegroundColor Yellow
+        Set-UnifiedGroup -Identity $group.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Reverted"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($group.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/groupe_distribution_migrate.ps1
+++ b/scripts/groupe_distribution_migrate.ps1
@@ -1,0 +1,36 @@
+# Migrates distribution groups from webetsolutions.com to oasis-projet.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_distgroups_to_oasis_$timestamp.log"
+$csvFile   = "./migration_distgroups_to_oasis_$timestamp.csv"
+$results   = @()
+
+$distGroups = Get-DistributionGroup
+foreach ($group in $distGroups) {
+    $prefix = $group.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@oasis-projet.com"
+    $oldAlias   = "smtp:$prefix@webetsolutions.com"
+    try {
+        Write-Host "➡ Migration: $($group.DisplayName) -> $newPrimary" -ForegroundColor Cyan
+        Set-DistributionGroup -Identity $group.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Migrated"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($group.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/groupe_distribution_migrate_inverse.ps1
+++ b/scripts/groupe_distribution_migrate_inverse.ps1
@@ -1,0 +1,36 @@
+# Rollback distribution groups from oasis-projet.com back to webetsolutions.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_distgroups_reverse_$timestamp.log"
+$csvFile   = "./migration_distgroups_reverse_$timestamp.csv"
+$results   = @()
+
+$distGroups = Get-DistributionGroup
+foreach ($group in $distGroups) {
+    $prefix = $group.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@webetsolutions.com"
+    $oldAlias   = "smtp:$prefix@oasis-projet.com"
+    try {
+        Write-Host "↩ Rétro-migration: $($group.DisplayName) -> $newPrimary" -ForegroundColor Yellow
+        Set-DistributionGroup -Identity $group.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Reverted"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($group.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/groupe_m365_migrate.ps1
+++ b/scripts/groupe_m365_migrate.ps1
@@ -1,0 +1,36 @@
+# Migrates M365 groups from webetsolutions.com to oasis-projet.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_groups_to_oasis_$timestamp.log"
+$csvFile   = "./migration_groups_to_oasis_$timestamp.csv"
+$results   = @()
+
+$groups = Get-UnifiedGroup
+foreach ($group in $groups) {
+    $prefix = $group.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@oasis-projet.com"
+    $oldAlias   = "smtp:$prefix@webetsolutions.com"
+    try {
+        Write-Host "➡ Migration: $($group.DisplayName) -> $newPrimary" -ForegroundColor Cyan
+        Set-UnifiedGroup -Identity $group.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Migrated"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($group.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $group.DisplayName
+            Identity    = $group.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/mailusers_other_system.ps1
+++ b/scripts/mailusers_other_system.ps1
@@ -1,0 +1,36 @@
+# Migrates mail users (other systems) from webetsolutions.com to oasis-projet.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_mailusers_to_oasis_$timestamp.log"
+$csvFile   = "./migration_mailusers_to_oasis_$timestamp.csv"
+$results   = @()
+
+$mailusers = Get-MailUser
+foreach ($mu in $mailusers) {
+    $prefix = $mu.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@oasis-projet.com"
+    $oldAlias   = "smtp:$prefix@webetsolutions.com"
+    try {
+        Write-Host "➡ Migration: $($mu.DisplayName) -> $newPrimary" -ForegroundColor Cyan
+        Set-MailUser -Identity $mu.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $mu.DisplayName
+            Identity    = $mu.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Migrated"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($mu.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $mu.DisplayName
+            Identity    = $mu.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/mailusers_other_system_inverse.ps1
+++ b/scripts/mailusers_other_system_inverse.ps1
@@ -1,0 +1,36 @@
+# Rollback mail users from oasis-projet.com back to webetsolutions.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_mailusers_reverse_$timestamp.log"
+$csvFile   = "./migration_mailusers_reverse_$timestamp.csv"
+$results   = @()
+
+$mailusers = Get-MailUser
+foreach ($mu in $mailusers) {
+    $prefix = $mu.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@webetsolutions.com"
+    $oldAlias   = "smtp:$prefix@oasis-projet.com"
+    try {
+        Write-Host "↩ Rétro-migration: $($mu.DisplayName) -> $newPrimary" -ForegroundColor Yellow
+        Set-MailUser -Identity $mu.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $mu.DisplayName
+            Identity    = $mu.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Reverted"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($mu.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $mu.DisplayName
+            Identity    = $mu.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/menu_migration.ps1
+++ b/scripts/menu_migration.ps1
@@ -1,0 +1,43 @@
+function Show-Menu {
+    Clear-Host
+    Write-Host "==== Menu de migration ====" -ForegroundColor Cyan
+    Write-Host "1 - Migrer boîtes utilisateurs"
+    Write-Host "2 - Rétro-migrer boîtes utilisateurs"
+    Write-Host "3 - Migrer boîtes partagées"
+    Write-Host "4 - Rétro-migrer boîtes partagées"
+    Write-Host "5 - Migrer groupes M365"
+    Write-Host "6 - Rétro-migrer groupes M365"
+    Write-Host "7 - Migrer groupes de distribution"
+    Write-Host "8 - Rétro-migrer groupes de distribution"
+    Write-Host "9 - Migrer contacts externes"
+    Write-Host "10 - Rétro-migrer contacts externes"
+    Write-Host "11 - Migrer mail users"
+    Write-Host "12 - Rétro-migrer mail users"
+    Write-Host "13 - Migrer salles et équipements"
+    Write-Host "14 - Rétro-migrer salles et équipements"
+    Write-Host "0 - Quitter"
+}
+
+do {
+    Show-Menu
+    $choice = Read-Host "Choix"
+    switch ($choice) {
+        "1" { ./bal_migrate.ps1 }
+        "2" { ./bal_migrate_inverse.ps1 }
+        "3" { ./balp_migrate.ps1 }
+        "4" { ./balp_migrate_inverse.ps1 }
+        "5" { ./groupe_m365_migrate.ps1 }
+        "6" { ./group_m365_migrate_inverse.ps1 }
+        "7" { ./groupe_distribution_migrate.ps1 }
+        "8" { ./groupe_distribution_migrate_inverse.ps1 }
+        "9" { ./contacts_externes_migrate.ps1 }
+        "10" { ./contacts_externes_migrate_inverse.ps1 }
+        "11" { ./mailusers_other_system.ps1 }
+        "12" { ./mailusers_other_system_inverse.ps1 }
+        "13" { ./salles_migrate.ps1 }
+        "14" { ./salles_migrate_inverse.ps1 }
+        "0" { Write-Host "Fin du script." }
+        default { Write-Host "Option invalide." -ForegroundColor Red }
+    }
+    if ($choice -ne "0") { Pause }
+} while ($choice -ne "0")

--- a/scripts/salles_migrate.ps1
+++ b/scripts/salles_migrate.ps1
@@ -1,0 +1,36 @@
+# Migrates room and equipment mailboxes from webetsolutions.com to oasis-projet.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_rooms_to_oasis_$timestamp.log"
+$csvFile   = "./migration_rooms_to_oasis_$timestamp.csv"
+$results   = @()
+
+$resources = Get-Mailbox -RecipientTypeDetails RoomMailbox, EquipmentMailbox
+foreach ($mb in $resources) {
+    $prefix = $mb.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@oasis-projet.com"
+    $oldAlias   = "smtp:$prefix@webetsolutions.com"
+    try {
+        Write-Host "➡ Migration: $($mb.DisplayName) -> $newPrimary" -ForegroundColor Cyan
+        Set-Mailbox -Identity $mb.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $mb.DisplayName
+            Identity    = $mb.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Migrated"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($mb.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $mb.DisplayName
+            Identity    = $mb.Identity
+            NewPrimary  = "$prefix@oasis-projet.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n✅ Migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green

--- a/scripts/salles_migrate_inverse.ps1
+++ b/scripts/salles_migrate_inverse.ps1
@@ -1,0 +1,36 @@
+# Rollback room and equipment mailboxes from oasis-projet.com back to webetsolutions.com
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$logFile   = "./migration_rooms_reverse_$timestamp.log"
+$csvFile   = "./migration_rooms_reverse_$timestamp.csv"
+$results   = @()
+
+$resources = Get-Mailbox -RecipientTypeDetails RoomMailbox, EquipmentMailbox
+foreach ($mb in $resources) {
+    $prefix = $mb.PrimarySmtpAddress.Local
+    $newPrimary = "SMTP:$prefix@webetsolutions.com"
+    $oldAlias   = "smtp:$prefix@oasis-projet.com"
+    try {
+        Write-Host "↩ Rétro-migration: $($mb.DisplayName) -> $newPrimary" -ForegroundColor Yellow
+        Set-Mailbox -Identity $mb.Identity -EmailAddresses @($newPrimary, $oldAlias)
+        $results += [pscustomobject]@{
+            DisplayName = $mb.DisplayName
+            Identity    = $mb.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Reverted"
+        }
+    } catch {
+        Write-Warning "⛔ Erreur sur $($mb.DisplayName): $_"
+        $results += [pscustomobject]@{
+            DisplayName = $mb.DisplayName
+            Identity    = $mb.Identity
+            NewPrimary  = "$prefix@webetsolutions.com"
+            Timestamp   = (Get-Date)
+            Status      = "Error: $($_.Exception.Message)"
+        }
+    }
+}
+
+$results | Tee-Object -FilePath $logFile | Out-Null
+$results | Export-Csv -Path $csvFile -NoTypeInformation -Encoding UTF8
+Write-Host "`n🔁 Rétro-migration terminée. Logs : $logFile`nCSV : $csvFile" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add PowerShell scripts for migrating all mail objects between domains
- add corresponding rollback scripts
- each script writes log/CSV files to satisfy KR5
- include a menu script to launch the tasks
- update README with usage info

## Testing
- `grep -r "Write-Host" -n scripts | head`
- `powershell` not available to run the scripts

------
https://chatgpt.com/codex/tasks/task_e_685e99dceefc832ebbdfd76adc4995f4